### PR TITLE
make fibonacci operate on 32 bit chunks when possible

### DIFF
--- a/src/fibonacci-hash.c
+++ b/src/fibonacci-hash.c
@@ -7,15 +7,15 @@
  */
 uint32_t fibonacci_32_hash(const void* data, int len)
 {
-    const unsigned char* d = data;
-    uint_fast32_t h = 0;
-    uint64_t tmp;
-    int i;
+	const uint_fast8_t* d8 = data;
+	const uint_fast32_t* d32 = data;
+	uint_fast32_t h = 0;
+	int i = 0;
 
-    for (i = 0 ; i < len ; i++) {
-        tmp = d[i] * 2654435915;
-        h += tmp >> 32;
-    }
+	for (; i < len/4; i++)
+		h += (d32[i] * 2654435915) >> 32;
+	for (i*=4 ; i < len; i++)
+		h += (d8[i] * 2654435915) >> 32;
 
-    return h;
+	return h;
 }


### PR DESCRIPTION
The golden ratio technique works best when the mapping domain has at least the same size as the mapping co-domain.