### PR TITLE
switch from uint_fast to uint data types

### DIFF
--- a/src/fiboat-hash.c
+++ b/src/fiboat-hash.c
@@ -2,40 +2,40 @@
 
 #include "hash-functions.h"
 
-#define FIBO_NUM 2654435915
+#define FIBO_NUM 2654435769ull
+#define FIBO_HASH(N) (((N * FIBO_NUM)*4294967295ull) >> 32)
 
 uint32_t fiboat_hash(const void* data, int len)
 {
-    const uint_fast8_t* d8 = data;
-    const uint_fast32_t* d32 = data;
-    uint_fast32_t g, h = 0;
-    int i = 0;
+	const uint8_t* d8 = data;
+	const uint32_t* d32 = data;
+	uint32_t g, h = 0;
+	int i = 0;
 
-    /* Fibonacci part */
-    for ( ; i < len / 4 ; i++)
-        h += (d32[i] * FIBO_NUM) >> 32;
+	// Fibonacci part
+	for (; i < len/4; i++)
+		h += FIBO_HASH(d32[i]);
 
-    if (i * 4 < len) {
-        g = 0;
-        for (i *= 4 ; i < len ; i++)
-            g += d8[i] << 8 * (len - 1 - i);
+	if (i*4 < len) {
+		g = 0;
+		for (i*=4 ; i < len; i++)
+			g += d8[i] << 8*(len-1-i);
 
-        h += (g * FIBO_NUM) >> 32;
-    }
+		h += FIBO_HASH(g);
+	}
 
-    /* On-a-time part */
-    d8 = (const uint_fast8_t*) &h;
-    g = 0;
-    len = 4;
-    for (i = 0 ; i < len ; i++) {
-        g += d8[i];
-        g += (g << 10);
-        g ^= (g >> 6);
-    }
+	// On-a-time part
+	d8 = (const uint8_t*) &h;
+	g = 0;
+	len = 4;
+	for (i = 0 ; i < len ; i++) {
+		g += d8[i];
+		g += (g << 10);
+		g ^= (g >> 6);
+	}
+	g += (g << 3);
+	g ^= (g >> 11);
+	g += (g << 15);
 
-    g += (g << 3);
-    g ^= (g >> 11);
-    g += (g << 15);
-
-    return g;
+	return g;
 }

--- a/src/fibonacci-hash.c
+++ b/src/fibonacci-hash.c
@@ -2,28 +2,26 @@
 
 #include "hash-functions.h"
 
-#define FIBO_NUM 2654435915
+#define FIBO_NUM 2654435769ull
+#define FIBO_HASH(N) (((N * FIBO_NUM)*4294967295ull) >> 32)
 
-/**
- * https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
- */
 uint32_t fibonacci_32_hash(const void* data, int len)
 {
-    const uint_fast8_t* d8 = data;
-    const uint_fast32_t* d32 = data;
-    uint_fast32_t g, h = 0;
-    int i = 0;
+	const uint8_t* d8 = data;
+	const uint32_t* d32 = data;
+	uint32_t g, h = 0;
+	int i = 0;
 
-    for ( ; i < len / 4 ; i++)
-        h += (d32[i] * FIBO_NUM) >> 32;
+	for (; i < len/4; i++)
+		h += FIBO_HASH(d32[i]);
 
-    if (i * 4 < len) {
-        g = 0;
-        for (i *= 4 ; i < len ; i++)
-            g += d8[i] << 8 * (len - 1 - i);
+	if (i*4 < len) {
+		g = 0;
+		for (i*=4 ; i < len; i++)
+			g += d8[i] << 8*(len-1-i);
 
-        h += (g * FIBO_NUM) >> 32;
-    }
+		h += FIBO_HASH(g);
+	}
 
-    return h;
+	return h;
 }


### PR DESCRIPTION
It solves memory handling issues

uint_fast32_t datatype grants to be *at least* 32 bit wide. Some machines have them implemented with 64 bit registers, hence, if they are used to read a data buffer, they can read chunks of 64 bits per time.